### PR TITLE
Add pages for admins

### DIFF
--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -1,2 +1,44 @@
 module AdminsHelper
+    def get_statistics
+        output = {
+            numUsers: get_users_count,
+            numAdmins: get_admins_count,
+            numManagers: get_managers_count,
+            numRiders: get_riders_count,
+            numCustomers: get_customers_count,
+            numRestaurants: get_restaurants_count,
+            numFood: get_food_count
+        }
+
+        return output
+    end
+
+    protected
+    def get_users_count
+        return User.all.count
+    end
+
+    def get_admins_count
+        return Admin.all.count
+    end
+
+    def get_managers_count
+        return Manager.all.count
+    end
+
+    def get_riders_count
+        return Rider.all.count
+    end
+
+    def get_customers_count
+        return Customer.all.count
+    end
+
+    def get_restaurants_count
+        return Restaurant.all.count
+    end
+
+    def get_food_count
+        return Food.all.count
+    end
 end

--- a/app/javascript/components/admins/Dashboard.js
+++ b/app/javascript/components/admins/Dashboard.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Dashboard = (props) => {
+    return (
+        <React.Fragment>
+            <h2>Welcome to the admins dashboard, {props.currentUser.username}!</h2>
+            <p>This page contains useful links for the management of this HungryDB instance.</p>
+            <h3>Useful links</h3>
+            <ul>
+                <li><Link to="/admin/roles">Roles management</Link></li>
+                <li><Link to="/admin/statistics">Statistics</Link></li>
+            </ul>
+       </React.Fragment>
+    )
+}
+
+export default Dashboard;

--- a/app/javascript/components/admins/Index.js
+++ b/app/javascript/components/admins/Index.js
@@ -1,14 +1,19 @@
 import React from 'react';
-import AppBar from '../global/AppBar';
+import { BrowserRouter as Router, Route } from 'react-router-dom'
 
+import Dashboard from './Dashboard';
+import NavBar from './NavBar';
+import Roles from './Roles';
+import Statistics from './Statistics';
 
 const Index = (props) => {
     return (
-        <React.Fragment>
-            <AppBar isLoggedIn={true} />
-            <h2>Hello {props.currentUser.username}!</h2>
-            <p>This user was updated on the Admins table on {props.roleAttributes.updated_at}</p>
-       </React.Fragment>
+        <Router>
+            <NavBar />
+            <Route exact path="/"><Dashboard currentUser={props.currentUser} roleAttributes={props.roleAttributes} /></Route>
+            <Route exact path="/admin/roles"><Roles currentUser={props.currentUser} /></Route>
+            <Route exact path="/admin/statistics"><Statistics statistics={props.statistics} /></Route>
+        </Router>
     )
 }
 

--- a/app/javascript/components/admins/NavBar.js
+++ b/app/javascript/components/admins/NavBar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import Nav from 'react-bootstrap/Nav';
+import AppBar from '../global/AppBar';
+import Colors from '../global/Colors';
+
+const NavBar = () => {
+    const navLinkStyle = Colors.navbarLink;
+
+    return (
+        <AppBar isLoggedIn={true}>
+            <Nav.Link as={NavLink} to="/admin/roles" style={navLinkStyle}>Roles management</Nav.Link>
+            <Nav.Link as={NavLink} to="/admin/statistics" style={navLinkStyle}>Statistics</Nav.Link>
+        </AppBar>
+    )
+}
+
+export default NavBar;

--- a/app/javascript/components/admins/Roles.js
+++ b/app/javascript/components/admins/Roles.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Formik } from 'formik';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import * as Yup from 'yup';
+
+const Roles = (props) => {
+    const validation = Yup.object({
+        identifier: Yup.string()
+            .matches(/^\w+$|^[\w+\-.]+@[a-z\d\-.]+\.[a-z]+$/)
+            .required()
+    });
+
+    const initialVals = {
+        identifier: ''
+    };
+
+    const handleRoleEdit = (values, formik) => {
+        console.log(values);
+
+        formik.setSubmitting(false);
+    }
+
+    return (
+        <Formik
+            validationSchema={validation}
+            initialValues={initialVals}
+            onSubmit={handleRoleEdit}
+        >
+            {({
+                handleSubmit,
+                handleChange,
+                values,
+                errors,
+                touched,
+                isSubmitting
+            }) => (
+            <Form onSubmit={handleSubmit}>
+                <Form.Group>
+                    <Form.Label>Username or Email</Form.Label>
+                    <Form.Control
+                        type="text"
+                        name="identifier"
+                        value={values.identifier}
+                        onChange={handleChange}
+                        isInvalid={touched.identifier && !!errors.identifier}
+                    />
+                    <Form.Control.Feedback type="invalid">Username or email is invalid.</Form.Control.Feedback>
+                </Form.Group>
+
+                <Button variant="primary" type="submit" disabled={isSubmitting}>
+                    Go
+                </Button>
+            </Form>
+           )}
+        </Formik>
+    )
+};
+
+export default Roles;

--- a/app/javascript/components/admins/Statistics.js
+++ b/app/javascript/components/admins/Statistics.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const Statistics = (props) => {
+    return (
+        <React.Fragment>
+            <h2>Statistics on HungryDB</h2>
+            <p>This page provides some statistics on the HungryDB instance.</p>
+            <h3>Users</h3>
+            <ul>
+                <li>Total number of users: {props.statistics.numUsers}</li>
+                <li>Number of admins: {props.statistics.numAdmins}</li>
+                <li>Number of managers: {props.statistics.numManagers}</li>
+                <li>Number of riders: {props.statistics.numRiders}</li>
+                <li>Number of customers: {props.statistics.numCustomers}</li>
+            </ul>
+            <h3>Restaurants</h3>
+            <ul>
+                <li>Number of restaurants: {props.statistics.numRestaurants}</li>
+                <li>Number of food items: {props.statistics.numFood}</li>
+            </ul>
+        </React.Fragment>
+    )
+}
+
+export default Statistics;

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -1,3 +1,1 @@
-if user_has_role?('admin')
-
-<%= react_component('admins/Index', currentUser: current_user, roleAttributes: get_role_attributes('admin')) %>
+<%= react_component('admins/Index', currentUser: current_user, roleAttributes: get_role_attributes('admin'), statistics: get_statistics) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
 
     scope '/admin' do
       get 'dashboard', to: 'admins#index'
+      get 'roles', to: 'admins#index'
+      get 'statistics', to: 'admins#index'
     end
 
     scope '/manager' do


### PR DESCRIPTION
This change adds new pages that are accessible by these routes:

- `/admin/roles`: For modifying roles of a specific user
- `/admin/statistics`: For displaying statistics

Most of the content are placeholders for now until we figure out more aspects of the program